### PR TITLE
Update onprem-flyte-core-values.yaml to avoid empty project list

### DIFF
--- a/docs/on-premises/single-node/manifests/onprem-flyte-core-values.yaml
+++ b/docs/on-premises/single-node/manifests/onprem-flyte-core-values.yaml
@@ -168,6 +168,9 @@ db:
 #
 
 configmap:
+  configmap:
+    console:
+      ADMIN_API_URL: http://localhost:8089
   adminServer:
     server:
       httpPort: 8088
@@ -177,8 +180,8 @@ configmap:
         useAuth: false
         allowCors: true
         allowedOrigins:
-          # Accepting all domains for Sandbox installation
-          - "*"
+          # Accepting localhost domains for Sandbox installation to avoid CORS issues
+          - "http://localhost:8088"
         allowedHeaders:
           - "Content-Type"
   k8s:


### PR DESCRIPTION
As frontend is communicating to the FlyteAdmin with the `ADMIN_API_URL` provided by configmap, we need to modify it for the sandbox installation so it communicates to it via port-forwarded loopback. 

To avoid CORS issues, we also need to modify adminServer allowedOrigins. 

https://github.com/flyteorg/flyte/issues/6037